### PR TITLE
Update README with updated smtp settings for Vertica

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,9 +107,6 @@ General purpose platform for running Tasks and Migrations expose (internally) HT
 
   Vertica example:
   ```xml
-  <smtp from="your-email@vertica.dk">
-        <network host="mail01.vertica.dk" />
-  </smtp>
   <smtp deliveryMethod="Network" from="your-email@vertica.dk">
         <network defaultCredentials="false" enableSsl="true" host="smtp.office365.com" port="587" password="askForPassword" userName="no-reply@vertica.dk" />
   </smtp>


### PR DESCRIPTION
Opdateret README med nye smtp informationer til Vertica e-mail udsendelse. Da vores mail server er lukket ned og vi nu kun har Office 365.