### PR TITLE
feat: clean up IntegrationDB in batches to prevent timeouts

### DIFF
--- a/src/Integration/Domain/Core/MaintenanceConfiguration.cs
+++ b/src/Integration/Domain/Core/MaintenanceConfiguration.cs
@@ -22,12 +22,16 @@ namespace Vertica.Integration.Domain.Core
         {
             CleanUpTaskLogEntriesOlderThan = TimeSpan.FromDays(60);
             CleanUpErrorLogEntriesOlderThan = TimeSpan.FromDays(60);
+            ArchiveDeletedLogEntries = true;
+            DeleteLogEntriesBatchSize = 200;
 
             ArchiveFolders = new ArchiveFoldersConfiguration();
         }
 
         public TimeSpan CleanUpTaskLogEntriesOlderThan { get; set; }
         public TimeSpan CleanUpErrorLogEntriesOlderThan { get; set; }
+        public bool ArchiveDeletedLogEntries { get; set; }
+        public int DeleteLogEntriesBatchSize { get; set; }
 
         public ArchiveFoldersConfiguration ArchiveFolders { get; }
 


### PR DESCRIPTION
- Added `bool ArchiveDeletedLogEntries` and `int DeleteLogEntriesBatchSize` to `MaintenanceConfiguration`
- Removed DbTransaction, since the SQL script will continually delete to prevent locks
- Moved the use of `SELECT` and `IArchiveService` behind `ArchiveDeletedLogEntries` check
- Added SQL script from `CleanUpElmahErrorsStep` and changed it to accept a table name